### PR TITLE
Updated /suggest Command to Announce New Module Submissions

### DIFF
--- a/commands/suggest.js
+++ b/commands/suggest.js
@@ -1,7 +1,56 @@
-const { SlashCommandBuilder, EmbedBuilder, Colors } = require('discord.js');
-const idclass = require('../idclass'); // Ensure this file contains the correct SuggestChannel ID
+const { 
+    SlashCommandBuilder, 
+    EmbedBuilder, 
+    ActionRowBuilder, 
+    ButtonBuilder, 
+    Colors,
+    ModalBuilder,
+    TextInputBuilder,
+    TextInputStyle
+} = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+const idclass = require('../idclass'); // Loads ChannelMRC and ChannelMR from idclass.js
 
-module.exports = {
+// Define the path for the JSON file to store suggestions
+const suggestionsFilePath = path.join(__dirname, '../suggestions.json');
+
+// Utility: load suggestions from JSON file
+function loadSuggestions() {
+    if (fs.existsSync(suggestionsFilePath)) {
+        try {
+            const data = fs.readFileSync(suggestionsFilePath, 'utf8');
+            const parsed = JSON.parse(data);
+            // If stored data is an array, convert it to an object keyed by suggestionMessageId.
+            if (Array.isArray(parsed)) {
+                const obj = {};
+                for (const suggestion of parsed) {
+                    obj[suggestion.suggestionMessageId] = suggestion;
+                }
+                return obj;
+            }
+            return parsed;
+        } catch (err) {
+            console.error("Error reading suggestions file:", err);
+            return {};
+        }
+    }
+    return {};
+}
+
+// Utility: save suggestions to JSON file (always as an object)
+function saveSuggestions(suggestions) {
+    try {
+        fs.writeFileSync(suggestionsFilePath, JSON.stringify(suggestions, null, 4));
+    } catch (err) {
+        console.error("Error writing suggestions file:", err);
+    }
+}
+
+// Create an in-memory cache for suggestions
+let suggestionsCache = loadSuggestions();
+
+const command = {
     data: new SlashCommandBuilder()
         .setName('suggest')
         .setDescription('Submit a suggestion with a name, link, language, and type')
@@ -25,47 +74,232 @@ module.exports = {
                     { name: 'Anime', value: 'Anime' },
                     { name: 'Movie/Show', value: 'Movie/Show' }
                 )),
-
     async execute(interaction) {
-        const name = interaction.options.getString('name');
-        const link = interaction.options.getString('link');
-        const language = interaction.options.getString('language');
-        const type = interaction.options.getString('type');
-        const suggestionChannel = interaction.guild.channels.cache.get(idclass.ChannelMRC);
-        const fallbackColor = '#ff9500'; // Default color if no link embed color is available
-
-        if (!suggestionChannel) {
-            return interaction.reply({ content: 'Suggestion channel not found.', ephemeral: true });
-        }
-
-        if (interaction.channelId !== idclass.ChannelMR) {
-            return interaction.reply({ content: `This command can only be used in <#${idclass.ChannelMR}>.`, ephemeral: true });
-        }
-
-        const faviconUrl = `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(link)}`;
-
-        // Send the link separately first to generate the preview embed
-        let linkEmbedColor = fallbackColor;
-        let messageWithLink;
         try {
-            messageWithLink = await suggestionChannel.send({ content: link });
-            if (messageWithLink.embeds.length > 0 && messageWithLink.embeds[0].color) {
-                linkEmbedColor = messageWithLink.embeds[0].color; // Use the link's embed color if available
+            // Defer reply using flags (64) for ephemeral response.
+            await interaction.deferReply({ flags: 64 });
+            
+            const name = interaction.options.getString('name');
+            const link = interaction.options.getString('link');
+            const language = interaction.options.getString('language');
+            const type = interaction.options.getString('type');
+
+            // Validate channels using idclass values.
+            const suggestionChannel = interaction.guild.channels.cache.get(idclass.ChannelMRC);
+            if (!suggestionChannel) {
+                return interaction.editReply({ content: 'Suggestion channel not found.' });
+            }
+            if (interaction.channelId !== idclass.ChannelMR) {
+                return interaction.editReply({ content: `This command can only be used in <#${idclass.ChannelMR}>.` });
+            }
+
+            // Prepare a favicon URL for the thumbnail.
+            const faviconUrl = `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(link)}`;
+
+            // Optionally try to fetch a preview image by sending the link (best effort).
+            let previewImage = null;
+            try {
+                const messageWithLink = await suggestionChannel.send({ content: link });
+                if (messageWithLink.embeds.length > 0) {
+                    const previewEmbed = messageWithLink.embeds[0];
+                    if (previewEmbed.image && previewEmbed.image.url) {
+                        previewImage = previewEmbed.image.url;
+                    }
+                }
+            } catch (error) {
+                console.error("Failed to fetch preview image:", error);
+            }
+
+            // Define pending color (orange).
+            const pendingColor = "#ff9500";
+
+            // Create the suggestion embed for the suggestion channel.
+            const suggestionEmbed = new EmbedBuilder()
+                .setTitle(name)
+                .setURL(link)
+                .setDescription(`**Type:** ${type}\n**Language:** ${language}\n${link}`)
+                .setColor(pendingColor)
+                .setThumbnail(faviconUrl)
+                .addFields({ name: 'Status', value: 'Pending' });
+            if (previewImage) suggestionEmbed.setImage(previewImage);
+
+            // Create an action row with Accept and Decline buttons.
+            const buttonsRow = new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setCustomId('suggestionAccept')
+                    .setLabel('Accept')
+                    .setStyle('Success'),
+                new ButtonBuilder()
+                    .setCustomId('suggestionDecline')
+                    .setLabel('Decline')
+                    .setStyle('Danger')
+            );
+
+            // Send the suggestion embed (with buttons) to the suggestion channel.
+            const suggestionMessage = await suggestionChannel.send({ embeds: [suggestionEmbed], components: [buttonsRow] });
+
+            // Create the public embed for the channel where the command was used.
+            const publicEmbed = new EmbedBuilder()
+                .setTitle('New Module Submission')
+                .setColor(pendingColor)
+                .addFields(
+                    { name: 'Module Name', value: name },
+                    { name: 'Module Type', value: type },
+                    { name: 'Module Link', value: `**${link}**` },
+                    { name: 'Submitted By', value: interaction.user.tag },
+                    { name: 'Status', value: 'Pending' }
+                )
+                .setThumbnail(faviconUrl)
+                .setFooter({ text: interaction.user.tag, iconURL: interaction.user.displayAvatarURL() });
+
+            // Send the public embed to the channel where the command was used.
+            const publicMessage = await interaction.channel.send({ embeds: [publicEmbed] });
+
+            // Update the in-memory cache using the suggestion message ID as the key.
+            suggestionsCache[suggestionMessage.id] = {
+                suggestionMessageId: suggestionMessage.id,
+                publicMessageId: publicMessage.id,
+                guildId: interaction.guild.id,
+                suggestionChannelId: suggestionChannel.id,
+                publicChannelId: interaction.channel.id,
+                name,
+                link,
+                language,
+                type,
+                status: 'Pending',
+                createdAt: Date.now()
+            };
+            saveSuggestions(suggestionsCache);
+
+            // Edit the deferred reply to confirm submission.
+            await interaction.editReply({ content: 'Suggestion submitted!' });
+        } catch (err) {
+            console.error("Error executing /suggest command:", err);
+            if (!interaction.deferred && !interaction.replied) {
+                await interaction.reply({ content: 'There was an error processing your suggestion.', flags: 64 });
+            } else {
+                await interaction.editReply({ content: 'There was an error processing your suggestion.' });
+            }
+        }
+    },
+    // Button handler for the suggestion command.
+    async buttonHandler(interaction) {
+        if (!interaction.isButton()) return;
+        if (!['suggestionAccept', 'suggestionDecline'].includes(interaction.customId)) return;
+
+        const suggestionMessageId = interaction.message.id;
+        if (!suggestionsCache[suggestionMessageId]) {
+            console.error("Suggestion not found in storage. Current cache:", suggestionsCache, "Requested ID:", suggestionMessageId);
+            return;
+        }
+        const suggestionData = suggestionsCache[suggestionMessageId];
+
+        let newStatus, newColor;
+        let reason = null; // Initialize reason as null
+
+        // Handle Accept button
+        if (interaction.customId === 'suggestionAccept') {
+            try {
+                // Defer update for accept interactions.
+                await interaction.deferUpdate();
+            } catch (error) {
+                console.error("Error deferring accept interaction:", error);
+                return;
+            }
+            newStatus = 'Approved';
+            newColor = Colors.Green;
+        }
+        // Handle Decline button (do not defer to allow modal to be shown)
+        else if (interaction.customId === 'suggestionDecline') {
+            // Create a modal to ask for a reason for decline.
+            const modal = new ModalBuilder()
+                .setCustomId(`declineModal_${suggestionMessageId}`)
+                .setTitle('Decline Reason');
+            const reasonInput = new TextInputBuilder()
+                .setCustomId('declineReason')
+                // Updated label to be under 45 characters.
+                .setLabel('Reason for decline (optional)')
+                .setStyle(TextInputStyle.Paragraph)
+                .setRequired(false);
+            const modalRow = new ActionRowBuilder().addComponents(reasonInput);
+            modal.addComponents(modalRow);
+            try {
+                await interaction.showModal(modal);
+            } catch (error) {
+                console.error("Error showing modal:", error);
+                return;
+            }
+            try {
+                // Wait for the modal submission.
+                const submitted = await interaction.awaitModalSubmit({
+                    filter: i => i.customId === `declineModal_${suggestionMessageId}` && i.user.id === interaction.user.id,
+                    time: 30000
+                });
+                reason = submitted.fields.getTextInputValue('declineReason').trim();
+                if (reason === "") {
+                    reason = null;
+                }
+                await submitted.reply({ content: 'Suggestion declined.', ephemeral: true});
+            } catch (err) {
+                console.error("Modal submission timed out or error:", err);
+                // If timeout/error, proceed without a reason.
+            }
+            newStatus = 'Declined';
+            newColor = Colors.Red;
+        }
+
+        // Update the suggestion embed in the suggestion channel.
+        try {
+            const suggestionChannel = interaction.guild.channels.cache.get(suggestionData.suggestionChannelId);
+            if (!suggestionChannel) throw new Error("Suggestion channel not found.");
+            const suggestionMessage = await suggestionChannel.messages.fetch(suggestionMessageId);
+            if (!suggestionMessage) throw new Error("Suggestion message not found.");
+            const oldEmbed = suggestionMessage.embeds[0];
+            const updatedEmbed = EmbedBuilder.from(oldEmbed)
+                .setColor(newColor)
+                .spliceFields(0, 1, { name: 'Status', value: newStatus });
+            // If a reason was provided, add a bolded field called "Reason".
+            if (reason) {
+                updatedEmbed.addFields({ name: '**Reason**', value: reason });
+            }
+            // Disable the buttons so they cannot be clicked again.
+            const oldRow = suggestionMessage.components[0];
+            const disabledRow = ActionRowBuilder.from(oldRow);
+            disabledRow.components = disabledRow.components.map(button => ButtonBuilder.from(button).setDisabled(true));
+            await suggestionMessage.edit({ embeds: [updatedEmbed], components: [disabledRow] });
+        } catch (error) {
+            console.error("Error updating suggestion message:", error);
+        }
+
+        // Update the public embed in the public channel.
+        try {
+            const publicChannel = interaction.guild.channels.cache.get(suggestionData.publicChannelId);
+            if (publicChannel) {
+                const publicMessage = await publicChannel.messages.fetch(suggestionData.publicMessageId);
+                if (publicMessage) {
+                    const oldPublicEmbed = publicMessage.embeds[0];
+                    const updatedPublicEmbed = EmbedBuilder.from(oldPublicEmbed)
+                        .setColor(newColor)
+                        .spliceFields(4, 1, { name: 'Status', value: newStatus });
+                    if (reason) {
+                        updatedPublicEmbed.addFields({ name: '**Reason**', value: reason });
+                    }
+                    await publicMessage.edit({ embeds: [updatedPublicEmbed] });
+                } else {
+                    console.error("Public message not found.");
+                }
+            } else {
+                console.error("Public channel not found.");
             }
         } catch (error) {
-            console.error("Failed to fetch embed metadata:", error);
+            console.error("Error updating public embed:", error);
         }
 
-        const embed = new EmbedBuilder()
-            .setTitle(name)
-            .setURL(link)
-            .setDescription(`**Type:** ${type}\n**Language:** ${language}\n${link}`)
-            .setColor(linkEmbedColor)
-            .setThumbnail(faviconUrl)
-            .setFooter({ text: `Suggested by ${interaction.user.tag}`, iconURL: interaction.user.displayAvatarURL() });
-
-        await suggestionChannel.send({ embeds: [embed] });
-
-        await interaction.reply({ content: 'Your suggestion has been submitted!', ephemeral: true });
+        // Update the in-memory cache and save to file.
+        suggestionsCache[suggestionMessageId].status = newStatus;
+        if (reason) suggestionsCache[suggestionMessageId].reason = reason;
+        saveSuggestions(suggestionsCache);
     }
 };
+
+module.exports = command;

--- a/sora.js
+++ b/sora.js
@@ -1,87 +1,81 @@
 const { Client, GatewayIntentBits, REST, Routes, Collection, ActivityType } = require('discord.js');
 const fs = require('fs');
 const path = require('path');
-require('dotenv').config(); // Load environment variables
+require('dotenv').config();
 
 // Initialize the bot
 const client = new Client({
     intents: [
-        GatewayIntentBits.Guilds, // Required for slash commands
+        GatewayIntentBits.Guilds, 
         GatewayIntentBits.GuildMessages,
         GatewayIntentBits.DirectMessages,
         GatewayIntentBits.MessageContent,
     ],
-    partials: ['CHANNEL'], // Required for handling DMs
+    partials: ['CHANNEL'],
 });
 
-// Load commands
 client.commands = new Collection();
-const commands = []; // Array for slash commands registration
+const commands = [];
 const commandsPath = path.join(__dirname, 'commands');
 const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
 
 for (const file of commandFiles) {
     const command = require(path.join(commandsPath, file));
     client.commands.set(command.data.name, command);
-    commands.push(command.data.toJSON()); // Prepare commands for global registration
+    commands.push(command.data.toJSON());
 }
 
-const autoReply = require('./events/auto-reply'); // Adjust path if needed
+// Global interaction handler for both slash commands and button interactions.
+client.on('interactionCreate', async (interaction) => {
+    try {
+        if (interaction.isChatInputCommand()) {
+            const command = client.commands.get(interaction.commandName);
+            if (!command) return;
+            await command.execute(interaction);
+        } else if (interaction.isButton()) {
+            // Only process buttons for the suggestion command.
+            if (['suggestionAccept', 'suggestionDecline'].includes(interaction.customId)) {
+                const command = client.commands.get('suggest');
+                if (command && command.buttonHandler) {
+                    await command.buttonHandler(interaction);
+                }
+            }
+        }
+    } catch (error) {
+        console.error(error);
+    }
+});
 
+// Auto-reply event (if needed)
+const autoReply = require('./events/auto-reply');
 client.on('messageCreate', async (message) => {
     if (!message.author.bot) {
-        autoReply(message); // Calls the auto-reply system
+        autoReply(message);
     }
 });
 
 // Register slash commands globally
 const rest = new REST({ version: '10' }).setToken(process.env.logintoken);
-
 (async () => {
     try {
         console.log('Started refreshing global application (/) commands.');
-
-        // Register all commands globally
-        await rest.put(Routes.applicationCommands(process.env.CLIENT_ID), {
-            body: commands,
-        });
-
+        await rest.put(Routes.applicationCommands(process.env.CLIENT_ID), { body: commands });
         console.log('Successfully reloaded global application (/) commands.');
     } catch (error) {
         console.error(error);
     }
 })();
 
-// Event: Bot ready
+// Bot ready event
 client.once('ready', () => {
     console.log(`Logged in as ${client.user.tag}`);
-    
     client.user.setPresence({
-            status: 'online',
-            activities: [{
-                name: 'Anime on Sora',
-                type: ActivityType.Watching,
-            }],
-        });
+        status: 'online',
+        activities: [{
+            name: 'Anime on Sora',
+            type: ActivityType.Watching,
+        }],
+    });
 });
 
-// Event: Handle interaction (commands)
-client.on('interactionCreate', async interaction => {
-    if (!interaction.isCommand()) return;
-
-    const command = client.commands.get(interaction.commandName);
-    if (!command) return;
-
-    try {
-        await command.execute(interaction);
-    } catch (error) {
-        console.error(error);
-        await interaction.reply({
-            content: 'There was an error executing this command.',
-            ephemeral: true,
-        });
-    }
-});
-
-// Log in to Discord
 client.login(process.env.logintoken);


### PR DESCRIPTION
- Modified the /suggest command to send a public message in the suggestion channel when a module is submitted.

- The message includes details such as module name, type, submitter, and status (default: pending).

- Removed interaction.deferUpdate() to fix execution errors.

- Ensured the command only runs in the designated suggestion command channel.

- Improved error handling for missing channels and link metadata retrieval.

- Added a reason option when declining suggestions as well as an acceptation etc.,